### PR TITLE
Added post-season to scripts/create-schedule

### DIFF
--- a/scripts/create-schedule
+++ b/scripts/create-schedule
@@ -7,7 +7,7 @@ import xml.dom.minidom as xml
 xml_base_url = 'http://www.nfl.com/ajax/scorestrip?'
 start_year = 2009 # Years before this don't seem to have JSON feeds.
 end_year = 2012
-season_types = (('PRE', 4), ('REG', 17))
+season_types = (('PRE', xrange(1, 4 + 1)), ('REG', xrange(1, 17 + 1)), ('POST', [ 18, 19, 20, 22 ]))
 
 print '# This file was automatically generated on %s by %s.' \
       % (datetime.now(), 'scripts/create-schedule')
@@ -15,8 +15,8 @@ print
 print 'games = ['
 
 for year in xrange(start_year, end_year + 1):
-    for season_type, num_weeks in season_types:
-        for week in xrange(1, num_weeks + 1):
+    for season_type, weeks in season_types:
+        for week in weeks:
             url = '%sseason=%d&seasonType=%s&week=%d' \
                   % (xml_base_url, year, season_type, week)
             dom = xml.parse(urllib2.urlopen(url))


### PR DESCRIPTION
I noticed you don't have the post-season in nflgame/schedule.py, so I added it to the create-schedule script. I realize that the rest of nflgame doesn't yet support post-season (e.g. in `__search_schedule`, you have

```
        if not preseason and t != "REG":
        continue
```

), but it's a place to start.
