### PR TITLE
Catch NoneType errors

### DIFF
--- a/nflgame/statmap.py
+++ b/nflgame/statmap.py
@@ -54,6 +54,9 @@ def values(category_id, yards):
         yards = int(yards)
     except ValueError:
         yards = 0
+    except TypeError:
+        #Catch errors if yards is a NoneType
+        yards = 0
 
     vals = {}
     if info['yds']:


### PR DESCRIPTION
If yards is a NoneType we need to catch a TypeError as well and set the value to 0 just as the ValueError does
