### PR TITLE
Update sched.py for Python 2.6 compatibility

### DIFF
--- a/nflgame/sched.py
+++ b/nflgame/sched.py
@@ -31,7 +31,10 @@ def _create_schedule(jsonf=None):
         d[gsis_id] = info
     last_updated = datetime.datetime.utcfromtimestamp(data.get('time', 0))
 
-    if (datetime.datetime.utcnow() - last_updated).total_seconds() >= day:
+	td = datetime.datetime.utcnow() - last_updated 
+	duration = td.seconds + (td.days * 24 * 3600)
+
+    if duration >= day:
         # Only try to update if we can write to the schedule file.
         if os.access(jsonf, os.W_OK):
             import nflgame.live


### PR DESCRIPTION
removed total_seconds() call, which breaks the script in Python 2.6, using a solution like this:
https://bitbucket.org/wnielson/django-chronograph/issue/21/timedeltatotal_seconds-requires-python-27
