### PR TITLE
Update live.py

### DIFF
--- a/nflgame/live.py
+++ b/nflgame/live.py
@@ -343,7 +343,7 @@ def _game_is_active(gameinfo, inactive_interval):
 
 def _game_datetime(gameinfo):
     hour, minute = gameinfo['time'].strip().split(':')
-    d = datetime.datetime(gameinfo['year'], gameinfo['month'], gameinfo['day'],
+    d = datetime.datetime(int(gameinfo['eid'][:4]), gameinfo['month'], gameinfo['day'],
                           (int(hour) + 12) % 24, int(minute))
     return pytz.timezone('US/Eastern').localize(d).astimezone(pytz.utc)
 


### PR DESCRIPTION
I discovered an issue where the live module remains in active mode (checking NFL.com every 15 seconds) even when there are no games currently being played. Since the NFL is currently in the postseason, the actual date/year of the playoff games should be 2015, but the current implementation is using gameinfo['year'] = 2014 for the gametime instead. Seems like gameinfo['year'] returns the season year, not the actual year of the game.

My code change takes the actual year from the first four digits of gameinfo['eid'] instead so that the gametime is set to the correct year.  