### PR TITLE
pep8 fixes.

### DIFF
--- a/nflgame/__init__.py
+++ b/nflgame/__init__.py
@@ -93,6 +93,7 @@ import nflgame.sched
 import nflgame.seq
 from nflgame.version import __version__
 
+assert OrderedDict  # Asserting the import for static analysis.
 VERSION = __version__  # Deprecated. Backwards compatibility.
 
 NoPlayers = nflgame.seq.GenPlayerStats(None)

--- a/nflgame/live.py
+++ b/nflgame/live.py
@@ -65,13 +65,13 @@ _WEEK_INTERVAL = 60 * 60 * 12
 How often to check what the current week is. By default, it is twice a day.
 """
 
-# _CUR_SCHEDULE_URL = "http://www.nfl.com/liveupdate/scorestrip/ss.xml"
+# _CUR_SCHEDULE = "http://www.nfl.com/liveupdate/scorestrip/ss.xml"
 # """
 # Pinged infrequently to discover the current week number, year and week type.
 # The actual schedule of games is taken from the schedule module.
 # """
 
-_CUR_SCHEDULE_URL = "http://static.nfl.com/liveupdate/scorestrip/postseason/ss.xml"
+_CUR_SCHEDULE = "http://static.nfl.com/liveupdate/scorestrip/postseason/ss.xml"
 """
 The URL for the XML schedule of the post season. This is only used
 during the post season.
@@ -341,9 +341,9 @@ def _game_is_active(gameinfo, inactive_interval):
     return gameinfo['eid'] not in _completed
 
 
-def _game_datetime(gameinfo):
-    hour, minute = gameinfo['time'].strip().split(':')
-    d = datetime.datetime(int(gameinfo['eid'][:4]), gameinfo['month'], gameinfo['day'],
+def _game_datetime(info):
+    hour, minute = info['time'].strip().split(':')
+    d = datetime.datetime(int(info['eid'][:4]), info['month'], info['day'],
                           (int(hour) + 12) % 24, int(minute))
     return pytz.timezone('US/Eastern').localize(d).astimezone(pytz.utc)
 
@@ -355,7 +355,7 @@ def _now():
 def _update_week_number():
     global _cur_week, _cur_year, _cur_season_phase
 
-    dom = xml.parse(urllib2.urlopen(_CUR_SCHEDULE_URL, timeout=5))
+    dom = xml.parse(urllib2.urlopen(_CUR_SCHEDULE, timeout=5))
     gms = dom.getElementsByTagName('gms')[0]
     _cur_week = int(gms.getAttribute('w'))
     _cur_year = int(gms.getAttribute('y'))

--- a/nflgame/sched.py
+++ b/nflgame/sched.py
@@ -10,6 +10,7 @@ __pdoc__ = {}
 
 _sched_json_file = os.path.join(os.path.dirname(__file__), 'schedule.json')
 
+
 def _create_schedule(jsonf=None):
     """
     Returns an ordered dict of schedule data from the schedule.json

--- a/nflgame/statmap.py
+++ b/nflgame/statmap.py
@@ -55,7 +55,7 @@ def values(category_id, yards):
     except ValueError:
         yards = 0
     except TypeError:
-        #Catch errors if yards is a NoneType
+        # Catch errors if yards is a NoneType
         yards = 0
 
     vals = {}

--- a/nflgame/update_players.py
+++ b/nflgame/update_players.py
@@ -61,6 +61,7 @@ urls = {
     'gsis_profile': 'http://www.nfl.com/players/profile?id=%s',
 }
 
+
 def new_http():
     http = httplib2.Http(timeout=10)
     http.follow_redirects = False


### PR DESCRIPTION
Fixes all of the (minor) pep8 warnings when scanning with flake8: whitespace, column width warnings and an "unused import" warning.