### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.py[co]
 *.egg*
 __pycache__/
-env/
+env*/
 
 .*.swp
 doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*.py[co]
+*.egg*
+__pycache__/
+env/
+
 .*.swp
 doc
 MANIFEST

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ games = nflgame.games(2013, week=1)
 players = nflgame.combine_game_stats(games)
 for p in players.rushing().sort('rushing_yds').limit(5):
     msg = '%s %d carries for %d yards and %d TDs'
-    print msg % (p, p.rushing_att, p.rushing_yds, p.rushing_tds)
+    print(msg % (p, p.rushing_att, p.rushing_yds, p.rushing_tds))
 ```
 
 And the output is:
@@ -47,7 +47,7 @@ import nflgame
 games = nflgame.games(2013, week=1)
 plays = nflgame.combine_plays(games)
 for p in plays.sort('passing_yds').limit(5):
-    print p
+    print(p)
 ```
 
 And the output is:
@@ -109,8 +109,6 @@ On all platforms, it is recommend to install it with `pip`:
 pip install nflgame
 ```
 
-(You may need to use `pip2` if Python 3 is the default on your system.)
-
 If you can't get `pip` to work on Windows, then you can try downloading the
 Windows installer on nflgame's PyPI page.
 
@@ -120,8 +118,7 @@ Python standard library, but `nflgame.live` depends on `pytz` and the
 All three dependencies are installed automatically if you install nflgame from
 PyPI with `pip`.
 
-nflgame does not yet work on Python 3, but it should work with Python 2.6 and
-2.7.
+nflgame works on Python 2.6, 2.7, and Python 3.3+
 
 
 ### Updating the player database (e.g., rosters)

--- a/nflgame/__init__.py
+++ b/nflgame/__init__.py
@@ -27,7 +27,7 @@ first week of the 2013 season:
     players = nflgame.combine_game_stats(games)
     for p in players.rushing().sort('rushing_yds').limit(5):
         msg = '%s %d carries for %d yards and %d TDs'
-        print msg % (p, p.rushing_att, p.rushing_yds, p.rushing_tds)
+        print(msg % (p, p.rushing_att, p.rushing_yds, p.rushing_tds))
 
 And the output is:
 
@@ -45,7 +45,7 @@ Or you could find the top 5 passing plays in the same time period:
     games = nflgame.games(2013, week=1)
     plays = nflgame.combine_plays(games)
     for p in plays.sort('passing_yds').limit(5):
-        print p
+        print(p)
 
 And the output is:
 
@@ -80,10 +80,6 @@ There are several active contributors to nflgame that watch the issue tracker.
 We tend to respond fairly quickly!
 """
 
-try:
-    from collections import OrderedDict
-except:
-    from ordereddict import OrderedDict  # from PyPI
 import itertools
 
 import nflgame.game
@@ -91,9 +87,9 @@ import nflgame.live
 import nflgame.player
 import nflgame.sched
 import nflgame.seq
+from nflgame.compat import itervalues, reduce
 from nflgame.version import __version__
 
-assert OrderedDict  # Asserting the import for static analysis.
 VERSION = __version__  # Deprecated. Backwards compatibility.
 
 NoPlayers = nflgame.seq.GenPlayerStats(None)
@@ -159,7 +155,7 @@ def find(name, team=None):
     If team is not None, it is used as an additional search constraint.
     """
     hits = []
-    for player in players.itervalues():
+    for player in itervalues(players):
         if player.name.lower() == name.lower():
             if team is None or team.lower() == player.team.lower():
                 hits.append(player)
@@ -425,7 +421,7 @@ def _search_schedule(year, week=None, home=None, away=None, kind='REG',
     (as opposed to waiting for a 404 error from NFL.com).
     """
     infos = []
-    for info in nflgame.sched.games.itervalues():
+    for info in itervalues(nflgame.sched.games):
         y, t, w = info['year'], info['season_type'], info['week']
         h, a = info['home'], info['away']
         if year is not None:

--- a/nflgame/alert.py
+++ b/nflgame/alert.py
@@ -78,6 +78,9 @@ typically need to be reused in a long running program. (i.e., If you don't
 send an alert for a while, you'll probably be disconnected from the SMTP
 server. In which case, the connection setup will be executed again.)
 """
+
+from __future__ import print_function
+
 import smtplib
 import sys
 
@@ -115,8 +118,8 @@ def google_voice_login(email, passwd):
     global _voice
 
     if not _gv_available:
-        print >> sys.stderr, "The pygooglevoice Python package is required " \
-                             "in order to use Google Voice."
+        print('The pygooglevoice Python package is required in order to use '
+              'Google Voice.', file=sys.stderr)
         return
 
     _voice = googlevoice.Voice()

--- a/nflgame/compat.py
+++ b/nflgame/compat.py
@@ -4,9 +4,8 @@ import sys
 
 from collections import namedtuple
 
-# Common constants
+
 IS_PY3 = sys.version_info[0] == 3
-string_types = (str if IS_PY3 else unicode, )
 
 
 # ifilter
@@ -29,14 +28,19 @@ try:
 except ImportError:
     from collections import OrderedDict  # Python 2.7 + Python 3
 
-assert OrderedDict  # Asserting the import for static analysis.
-
 
 # reduce
 try:
     reduce
 except NameError:
     from functools import reduce
+
+
+# Asserting the imports for static analysis.
+assert ifilter
+assert MAXINT
+assert OrderedDict
+assert reduce
 
 
 # urllib
@@ -55,22 +59,49 @@ except ImportError:
     del urllib_error, urllib_request
 
 
-# Dict iter functions
-def iteritems(obj, **kwargs):
-    return iter(obj.items(**kwargs)) if IS_PY3 else obj.iteritems(**kwargs)
+# Python 3
+if IS_PY3:
+    # Constants
+    binary_type = bytes
+    text_type = str
+
+    # Dict iter functions
+    def iteritems(obj, **kwargs):
+        return iter(obj.items(**kwargs))
+
+    def iterkeys(obj, **kwargs):
+        return iter(obj.keys(**kwargs))
+
+    def itervalues(obj, **kwargs):
+        return iter(obj.values(**kwargs))
+# Python 2
+else:
+    # Constants
+    binary_type = str
+    input = raw_input  # noqa
+    range = xrange  # noqa
+    text_type = unicode  # noqa
+
+    # Dict iter functions
+    def iteritems(obj, **kwargs):
+        return obj.iteritems(**kwargs)
+
+    def iterkeys(obj, **kwargs):
+        return obj.iterkeys(**kwargs)
+
+    def itervalues(obj, **kwargs):
+        return obj.itervalues(**kwargs)
 
 
-def iterkeys(obj, **kwargs):
-    return iter(obj.keys(**kwargs)) if IS_PY3 else obj.iterkeys(**kwargs)
+# String functions
+def force_binary(value, encoding='utf-8', errors='strict'):
+    if isinstance(value, binary_type):
+        return value
+    return value.encode(encoding, errors)
 
 
-def itervalues(obj, **kwargs):
-    return iter(obj.values(**kwargs)) if IS_PY3 else obj.itervalues(**kwargs)
-
-
-# String/unicode functions
-def force_unicode(value, encoding='utf-8', errors='strict'):
-    if isinstance(value, string_types):
+def force_text(value, encoding='utf-8', errors='strict'):
+    if isinstance(value, text_type):
         return value
     return value.decode(encoding, errors)
 

--- a/nflgame/compat.py
+++ b/nflgame/compat.py
@@ -1,0 +1,78 @@
+"""Python 2 & 3 compatibility layer for nflgame."""
+
+import sys
+
+from collections import namedtuple
+
+# Common constants
+IS_PY3 = sys.version_info[0] == 3
+string_types = (str if IS_PY3 else unicode, )
+
+
+# ifilter
+try:
+    from itertools import ifilter
+except ImportError:
+    ifilter = filter  # Python 3
+
+
+# MAXINT
+try:
+    from sys import maxint as MAXINT
+except ImportError:
+    from sys import maxsize as MAXINT  # Python 3
+
+
+# OrderedDict
+try:
+    from ordereddict import OrderedDict  # from PyPI
+except ImportError:
+    from collections import OrderedDict  # Python 2.7 + Python 3
+
+assert OrderedDict  # Asserting the import for static analysis.
+
+
+# reduce
+try:
+    reduce
+except NameError:
+    from functools import reduce
+
+
+# urllib
+urllib_ns = namedtuple('urllib', ('HTTPError', 'URLError', 'urlopen'))
+
+try:
+    import urllib2
+    urllib = urllib_ns(urllib2.HTTPError, urllib2.URLError, urllib2.urlopen)
+    del urllib2
+except ImportError:
+    # Python 3
+    from urllib import error as urllib_error, request as urllib_request
+    urllib = urllib_ns(urllib_error.HTTPError,
+                       urllib_error.URLError,
+                       urllib_request.urlopen)
+    del urllib_error, urllib_request
+
+
+# Dict iter functions
+def iteritems(obj, **kwargs):
+    return iter(obj.items(**kwargs)) if IS_PY3 else obj.iteritems(**kwargs)
+
+
+def iterkeys(obj, **kwargs):
+    return iter(obj.keys(**kwargs)) if IS_PY3 else obj.iterkeys(**kwargs)
+
+
+def itervalues(obj, **kwargs):
+    return iter(obj.values(**kwargs)) if IS_PY3 else obj.itervalues(**kwargs)
+
+
+# String/unicode functions
+def force_unicode(value, encoding='utf-8', errors='strict'):
+    if isinstance(value, string_types):
+        return value
+    return value.decode(encoding, errors)
+
+
+del namedtuple, urllib_ns

--- a/nflgame/compat.py
+++ b/nflgame/compat.py
@@ -31,9 +31,9 @@ except ImportError:
 
 # reduce
 try:
-    reduce
+    reduce = reduce
 except NameError:
-    from functools import reduce
+    from functools import reduce  # Python 3
 
 
 # Asserting the imports for static analysis.

--- a/nflgame/game.py
+++ b/nflgame/game.py
@@ -5,15 +5,19 @@ import gzip
 import json
 import socket
 import sys
-import urllib2
 
-from nflgame import OrderedDict
 import nflgame.player
 import nflgame.sched
 import nflgame.seq
 import nflgame.statmap
-
-_MAX_INT = sys.maxint
+from nflgame.compat import (
+    force_unicode,
+    iteritems,
+    itervalues,
+    MAXINT,
+    OrderedDict,
+    urllib,
+)
 
 _jsonf = path.join(path.split(__file__)[0], 'gamecenter-json', '%s.json.gz')
 _json_base_url = "http://www.nfl.com/liveupdate/game-center/%s/%s_gtd.json"
@@ -165,7 +169,7 @@ class GameClock (object):
             elif self.is_halftime():
                 self.__qtr = 3
             elif self.is_final():
-                self.__qtr = sys.maxint
+                self.__qtr = MAXINT
             else:
                 self.qtr = 'Pregame'
 
@@ -223,7 +227,7 @@ class Game (object):
         # If we can't get a valid JSON data, exit out and return None.
         try:
             rawData = _get_json_data(eid, fpath)
-        except urllib2.URLError:
+        except urllib.URLError:
             return None
         if rawData is None or rawData.strip() == '{}':
             return None
@@ -237,7 +241,7 @@ class Game (object):
             else:  # For when we have rawData (fpath) and no eid.
                 game.eid = None
                 game.data = json.loads(game.rawData)
-                for k, v in game.data.iteritems():
+                for k, v in iteritems(game.data):
                     if isinstance(v, dict):
                         game.eid = k
                         game.data = v
@@ -378,21 +382,21 @@ class Game (object):
                                                   pplay.name, pplay.home,
                                                   pplay.team)
             maxstats = {}
-            for stat, val in pplay._stats.iteritems():
+            for stat, val in iteritems(pplay._stats):
                 maxstats[stat] = val
 
             newp._overwrite_stats(maxstats)
             max_players[pplay.playerid] = newp
 
-        for newp in max_players.itervalues():
+        for newp in itervalues(max_players):
             for pgame in game_players:
                 if pgame.playerid != newp.playerid:
                     continue
 
                 maxstats = {}
-                for stat, val in pgame._stats.iteritems():
+                for stat, val in iteritems(pgame._stats):
                     maxstats[stat] = max([val,
-                                          newp._stats.get(stat, -_MAX_INT)])
+                                          newp._stats.get(stat, -MAXINT)])
 
                 newp._overwrite_stats(maxstats)
                 break
@@ -589,7 +593,7 @@ class Play (object):
                     continue
                 statvals = nflgame.statmap.values(info['statId'],
                                                   info['yards'])
-                for k, v in statvals.iteritems():
+                for k, v in iteritems(statvals):
                     v = self.__dict__.get(k, 0) + v
                     self.__dict__[k] = v
                     self._stats[k] = v
@@ -604,7 +608,7 @@ class Play (object):
         self.__players = _json_play_players(self, data['players'])
         self.players = nflgame.seq.GenPlayerStats(self.__players)
         for p in self.players:
-            for k, v in p.stats.iteritems():
+            for k, v in iteritems(p.stats):
                 # Sometimes we may see duplicate statistics (like tackle
                 # assists). Let's just overwrite in this case, since this
                 # data is from the perspective of the play. i.e., there
@@ -708,7 +712,7 @@ def _json_play_players(play, data):
     to determine whether the player belong to the home team or not.
     """
     players = OrderedDict()
-    for playerid, statcats in data.iteritems():
+    for playerid, statcats in iteritems(data):
         if playerid == '0':
             continue
         for info in statcats:
@@ -734,7 +738,7 @@ def _json_play_events(data):
     Takes a single JSON play entry (data) and converts it to a list of events.
     """
     temp = list()
-    for playerid, statcats in data.iteritems():
+    for playerid, statcats in iteritems(data):
         for info in statcats:
             if info['statId'] not in nflgame.statmap.idmap:
                 continue
@@ -757,9 +761,9 @@ def _json_game_player_stats(game, data):
         for category in nflgame.statmap.categories:
             if category not in data[team]['stats']:
                 continue
-            for pid, raw in data[team]['stats'][category].iteritems():
+            for pid, raw in iteritems(data[team]['stats'][category]):
                 stats = {}
-                for k, v in raw.iteritems():
+                for k, v in iteritems(raw):
                     if k == 'name':
                         continue
                     stats['%s_%s' % (category, k)] = v
@@ -791,14 +795,16 @@ def _get_json_data(eid=None, fpath=None):
     assert eid is not None or fpath is not None
 
     if fpath is not None:
-        return gzip.open(fpath).read()
+        return force_unicode(gzip.open(fpath).read())
 
     fpath = _jsonf % eid
     if os.access(fpath, os.R_OK):
-        return gzip.open(fpath).read()
+        return force_unicode(gzip.open(fpath).read())
+
     try:
-        return urllib2.urlopen(_json_base_url % (eid, eid), timeout=5).read()
-    except urllib2.HTTPError:
+        response = urllib.urlopen(_json_base_url % (eid, eid), timeout=5).read()
+        return force_unicode(response)
+    except urllib.HTTPError:
         pass
     except socket.timeout:
         pass

--- a/nflgame/live.py
+++ b/nflgame/live.py
@@ -40,7 +40,6 @@ will probably affect the API at least a little bit.
 """
 import datetime
 import time
-import urllib2
 import xml.dom.minidom as xml
 
 try:
@@ -50,6 +49,7 @@ except ImportError:
 
 import nflgame
 import nflgame.game
+from nflgame.compat import urllib
 
 # [00:21] <rasher> burntsushi: Alright, the schedule changes on Wednesday 7:00
 # UTC during the regular season
@@ -355,7 +355,7 @@ def _now():
 def _update_week_number():
     global _cur_week, _cur_year, _cur_season_phase
 
-    dom = xml.parse(urllib2.urlopen(_CUR_SCHEDULE, timeout=5))
+    dom = xml.parse(urllib.urlopen(_CUR_SCHEDULE, timeout=5))
     gms = dom.getElementsByTagName('gms')[0]
     _cur_week = int(gms.getAttribute('w'))
     _cur_year = int(gms.getAttribute('y'))

--- a/nflgame/player.py
+++ b/nflgame/player.py
@@ -3,9 +3,9 @@ from __future__ import division
 import json
 import os.path
 
-from nflgame import OrderedDict
 import nflgame.seq
 import nflgame.statmap
+from nflgame.compat import iteritems, OrderedDict
 
 _player_json_file = os.path.join(os.path.dirname(__file__), 'players.json')
 
@@ -177,7 +177,7 @@ class PlayerStats (object):
         all statistical categories.
         """
         n = 0
-        for f, v in self.__dict__.iteritems():
+        for f, v in iteritems(self.__dict__):
             if f.endswith('tds'):
                 n += v
         return n
@@ -224,17 +224,17 @@ class PlayerStats (object):
         Returns a roughly-formatted string of all statistics for this player.
         """
         s = []
-        for stat, val in self._stats.iteritems():
+        for stat, val in iteritems(self._stats):
             s.append('%s: %s' % (stat, val))
         return ', '.join(s)
 
     def _add_stats(self, stats):
-        for k, v in stats.iteritems():
+        for k, v in iteritems(stats):
             self.__dict__[k] = self.__dict__.get(k, 0) + v
             self._stats[k] = self.__dict__[k]
 
     def _overwrite_stats(self, stats):
-        for k, v in stats.iteritems():
+        for k, v in iteritems(stats):
             self.__dict__[k] = v
             self._stats[k] = self.__dict__[k]
 
@@ -278,7 +278,7 @@ class PlayerStats (object):
         new_player = GamePlayerStats(self.playerid,
                                      self.name, self.home, self.team)
         new_player._add_stats(self._stats)
-        for bk, bv in other._stats.iteritems():
+        for bk, bv in iteritems(other._stats):
             if bk not in new_player._stats:  # stat was taken away? ignore.
                 continue
 
@@ -289,7 +289,7 @@ class PlayerStats (object):
                 new_player.__dict__[bk] = new_player._stats[bk]
 
         anydiffs = False
-        for k, v in new_player._stats.iteritems():
+        for k, v in iteritems(new_player._stats):
             if v > 0:
                 anydiffs = True
                 break

--- a/nflgame/seq.py
+++ b/nflgame/seq.py
@@ -2,8 +2,8 @@ import functools
 import itertools
 import operator
 
-from nflgame import OrderedDict
 from nflgame import statmap
+from nflgame.compat import ifilter, iteritems, itervalues, OrderedDict
 
 _BUILTIN_PREDS = {
     '__lt': operator.lt,
@@ -77,9 +77,10 @@ class Gen (object):
         (Django users should feel right at home.)
         """
         preds = []
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             def pred(field, value, item):
-                for suffix, p in _BUILTIN_PREDS.iteritems():
+                # TODO: Move pred function outside of loop
+                for suffix, p in iteritems(_BUILTIN_PREDS):
                     if field.endswith(suffix):
                         f = field[:field.index(suffix)]
                         if not hasattr(item, f) or getattr(item, f) is None:
@@ -92,8 +93,7 @@ class Gen (object):
                 return getattr(item, field) == value
             preds.append(functools.partial(pred, k, v))
 
-        gen = itertools.ifilter(lambda item: all([f(item) for f in preds]),
-                                self)
+        gen = ifilter(lambda item: all([f(item) for f in preds]), self)
         return self.__class__(gen)
 
     def limit(self, n):
@@ -125,7 +125,7 @@ class Gen (object):
         if self.__iter is None:
             return iter([])
         if isinstance(self.__iter, OrderedDict):
-            return self.__iter.itervalues()
+            return itervalues(self.__iter)
         return iter(self.__iter)
 
     def __reversed__(self):
@@ -240,8 +240,7 @@ class GenPlayerStats (Gen):
         return self.__class__(gen())
 
     def __filter_category(self, cat):
-        return self.__class__(itertools.ifilter(lambda p: p.has_cat(cat),
-                                                self))
+        return self.__class__(ifilter(lambda p: p.has_cat(cat), self))
 
     def passing(self):
         """Returns players that have a "passing" statistical category."""
@@ -302,10 +301,10 @@ class GenPlayerStats (Gen):
         fields, rows = set([]), []
         players = list(self)
         for p in players:
-            for field, stat in p.stats.iteritems():
+            for field, stat in iteritems(p.stats):
                 fields.add(field)
         if allfields:
-            for statId, info in statmap.idmap.iteritems():
+            for statId, info in iteritems(statmap.idmap):
                 for field in info['fields']:
                     fields.add(field)
         fields = sorted(list(fields))

--- a/nflgame/update_players.py
+++ b/nflgame/update_players.py
@@ -55,6 +55,7 @@ from bs4 import BeautifulSoup
 import nflgame
 import nflgame.live
 import nflgame.player
+from nflgame.compat import itervalues
 
 urls = {
     'roster': 'http://www.nfl.com/teams/roster?team=%s',
@@ -345,7 +346,7 @@ def run():
         players = {}
 
         # Grab players one game a time to avoid obscene memory requirements.
-        for _, schedule in nflgame.sched.games.itervalues():
+        for _, schedule in itervalues(nflgame.sched.games):
             # If the game is too far in the future, skip it...
             if nflgame.live._game_datetime(schedule) > nflgame.live._now():
                 continue

--- a/nflgame/update_players.py
+++ b/nflgame/update_players.py
@@ -55,7 +55,7 @@ from bs4 import BeautifulSoup
 import nflgame
 import nflgame.live
 import nflgame.player
-from nflgame.compat import itervalues
+from nflgame.compat import input, itervalues
 
 urls = {
     'roster': 'http://www.nfl.com/teams/roster?team=%s',
@@ -331,7 +331,7 @@ def run():
         eprint("It is strongly recommended to find the 'players.json' file "
                "that comes with nflgame.")
         eprint("Are you sure you want to continue? [y/n] ", end='')
-        answer = raw_input()
+        answer = input()
         if answer[0].lower() != 'y':
             eprint("Quitting...")
             sys.exit(1)

--- a/nflgame/update_sched.py
+++ b/nflgame/update_sched.py
@@ -7,15 +7,15 @@ import sys
 import xml.dom.minidom as xml
 
 import nflgame
-from nflgame.compat import OrderedDict, urllib
+from nflgame.compat import OrderedDict, range, urllib
 
 
 def year_phase_week(year=None, phase=None, week=None):
     cur_year, _ = nflgame.live.current_year_and_week()
     season_types = (
-        ('PRE', xrange(0, 4 + 1)),
-        ('REG', xrange(1, 17 + 1)),
-        ('POST', xrange(1, 4 + 1)),
+        ('PRE', range(0, 4 + 1)),
+        ('REG', range(1, 17 + 1)),
+        ('POST', range(1, 4 + 1)),
     )
     for y in range(2009, cur_year+1):
         if year is not None and year != y:
@@ -55,7 +55,7 @@ def week_schedule(year, stype, week):
     try:
         dom = xml.parse(urllib.urlopen(url))
     except urllib.HTTPError:
-        print >> sys.stderr, 'Could not load %s' % url
+        print('Could not load %s' % url, file=sys.stderr)
         return []
 
     games = []

--- a/nflgame/update_sched.py
+++ b/nflgame/update_sched.py
@@ -4,11 +4,10 @@ import time
 import json
 import os
 import sys
-import urllib2
 import xml.dom.minidom as xml
 
 import nflgame
-from nflgame import OrderedDict
+from nflgame.compat import OrderedDict, urllib
 
 
 def year_phase_week(year=None, phase=None, week=None):
@@ -54,8 +53,8 @@ def week_schedule(year, stype, week):
     """
     url = schedule_url(year, stype, week)
     try:
-        dom = xml.parse(urllib2.urlopen(url))
-    except urllib2.HTTPError:
+        dom = xml.parse(urllib.urlopen(url))
+    except urllib.HTTPError:
         print >> sys.stderr, 'Could not load %s' % url
         return []
 


### PR DESCRIPTION
Port `nflgame` to work on Python 3.3+ as well as on Python 2.6 and 2.7. This fixes #78 

To test changes I used simple *test-suite* with examples from README,

```python
import nflgame

games = nflgame.games(2013, week=1)
players = nflgame.combine_game_stats(games)
for player in players.rushing().sort('rushing_yds').limit(5):
    print('{0} {0.rushing_att} carries for {0.rushing_yds} yards and '
          '{0.rushing_tds} TDs'.format(player))

plays = nflgame.combine_plays(games)
for play in plays.sort('passing_yds').limit(5):
    print(play)
```

Feel free to update test suite to ensure that all necessary features of `nflgame` still works properly after migration