### PR TITLE
Update playoff schedule URL

### DIFF
--- a/nflgame/live.py
+++ b/nflgame/live.py
@@ -70,8 +70,8 @@ How often to check what the current week is. By default, it is twice a day.
 # Pinged infrequently to discover the current week number, year and week type.
 # The actual schedule of games is taken from the schedule module.
 # """
+_CUR_SCHEDULE = "http://www.nfl.com/liveupdate/scorestrip/postseason/ss.xml"
 
-_CUR_SCHEDULE = "http://static.nfl.com/liveupdate/scorestrip/postseason/ss.xml"
 """
 The URL for the XML schedule of the post season. This is only used
 during the post season.


### PR DESCRIPTION
NFL.com appears to have removed static.nfl.com URL