### PR TITLE
update(team): updated the teams to reflect Los Angeles Rams

### DIFF
--- a/nflgame/__init__.py
+++ b/nflgame/__init__.py
@@ -146,7 +146,7 @@ teams = [
     ['SD', 'San Diego', 'Chargers', 'San Diego Chargers', 'S.D.', 'SDG'],
     ['SEA', 'Seattle', 'Seahawks', 'Seattle Seahawks'],
     ['SF', 'San Francisco', '49ers', 'San Francisco 49ers', 'S.F.', 'SFO'],
-    ['STL', 'St. Louis', 'Rams', 'St. Louis Rams', 'S.T.L.'],
+    ['LA', 'Los Angeles', 'Rams', 'Los Angeles Rams', 'L.A.'],
     ['TB', 'Tampa Bay', 'Buccaneers', 'Tampa Bay Buccaneers', 'T.B.', 'TAM'],
     ['TEN', 'Tennessee', 'Titans', 'Tennessee Titans'],
     ['WAS', 'Washington', 'Redskins', 'Washington Redskins', 'WSH'],


### PR DESCRIPTION
@BurntSushi hey Andrew, I've updated the STL Rams to LA Rams, the abbreviation seems to LA, that is what nfl.com uses. Please verify and merge if all is well. Thanks.
Also if you could let us know when the next build will be sent to pip install repo. Thanks.