### PR TITLE
Adjusted write mode on csv writer

### DIFF
--- a/nflgame/seq.py
+++ b/nflgame/seq.py
@@ -330,7 +330,7 @@ class GenPlayerStats (Gen):
 
         fieldNames = ["name", "id", "home", "team", "pos"] + fields
         rows = [dict((f, f) for f in fieldNames)] + rows
-        csv.DictWriter(open(fileName, 'w+'), fieldNames).writerows(rows)
+        csv.DictWriter(open(fileName, 'wb'), fieldNames).writerows(rows)
 
     def __add__(self, other):
         """


### PR DESCRIPTION
Regarding issue #204 

Adjusted write mode on csv writer to 'wb' in the bottom of seq.py to account for how Windows deals with writing new lines in text mode.