### PR TITLE
Add 2015 Divisional and Championship playoffs

### DIFF
--- a/nflgame/schedule.json
+++ b/nflgame/schedule.json
@@ -37382,6 +37382,108 @@
    }
   ],
   [
+   "2016011600",
+   {
+    "away": "KC",
+    "day": 16,
+    "eid": "2016011600",
+    "gamekey": "56828",
+    "home": "NE",
+    "meridiem": "PM",
+    "month": 1,
+    "season_type": "POST",
+    "time": "4:35",
+    "wday": "Sat",
+    "week": 2,
+    "year": 2015
+   }
+  ],
+  [
+   "2016011601",
+   {
+    "away": "GB",
+    "day": 16,
+    "eid": "2016011601",
+    "gamekey": "56829",
+    "home": "ARI",
+    "meridiem": "PM",
+    "month": 1,
+    "season_type": "POST",
+    "time": "8:15",
+    "wday": "Sat",
+    "week": 2,
+    "year": 2015
+   }
+  ],
+  [
+   "2016011700",
+   {
+    "away": "SEA",
+    "day": 17,
+    "eid": "2016011700",
+    "gamekey": "56830",
+    "home": "CAR",
+    "meridiem": "PM",
+    "month": 1,
+    "season_type": "POST",
+    "time": "1:05",
+    "wday": "Sun",
+    "week": 2,
+    "year": 2015
+   }
+  ],
+  [
+   "2016011701",
+   {
+    "away": "PIT",
+    "day": 17,
+    "eid": "2016011701",
+    "gamekey": "56831",
+    "home": "DEN",
+    "meridiem": "PM",
+    "month": 1,
+    "season_type": "POST",
+    "time": "4:40",
+    "wday": "Sun",
+    "week": 2,
+    "year": 2015
+   }
+  ],
+  [
+   "2016012400",
+   {
+    "away": "NE",
+    "day": 24,
+    "eid": "2016012400",
+    "gamekey": "56832",
+    "home": "DEN",
+    "meridiem": "PM",
+    "month": 1,
+    "season_type": "POST",
+    "time": "3:05",
+    "wday": "Sun",
+    "week": 3,
+    "year": 2015
+   }
+  ],
+  [
+   "2016012401",
+   {
+    "away": "ARI",
+    "day": 24,
+    "eid": "2016012401",
+    "gamekey": "56833",
+    "home": "CAR",
+    "meridiem": "PM",
+    "month": 1,
+    "season_type": "POST",
+    "time": "6:40",
+    "wday": "Sun",
+    "week": 3,
+    "year": 2015
+   }
+  ],
+  [
    "2016020700",
    {
     "away": "CAR",


### PR DESCRIPTION
Correct the schedule to add the missing 2015 NFC and AFC Divisional and Championship playoff games.

Fixes #238 