### PR TITLE
Updated meta_from_soup_row to handle parsing names with two commas

### DIFF
--- a/nflgame/update_players.py
+++ b/nflgame/update_players.py
@@ -176,7 +176,7 @@ def meta_from_soup_row(team, soup_row):
     if ',' not in name:
         last_name, first_name = name, ''
     else:
-        last_name, first_name = map(lambda s: s.strip(), name.split(','))
+        last_name, first_name = map(lambda s: s.strip(), name.split(',',  1))
 
     return {
         'team': team,


### PR DESCRIPTION
Fix for issue https://github.com/BurntSushi/nfldb/issues/214.  Added a max-split parameter to the string's split function so that player names are split once.

This solves the issue of unpacking the parts of a name, but now technically the player names in the database will be kind of weird, since the player's suffix will be a part of the first name.  See the name which causes the problem: Leno, Charles, Jr

Potentially a further fix could be:
name = tds[1].a.get_text().strip()
    if ',' not in name:
        last_name, first_name = name, ''
    else:
        last_name, first_name, suffix = map(lambda s: s.strip(), name.split(','))
        last_name = last_name + ', ' + suffix
