### PR TITLE
Longer HTTP timeout

### DIFF
--- a/nflgame/update_players.py
+++ b/nflgame/update_players.py
@@ -73,7 +73,7 @@ urls = {
 
 
 def new_http():
-    http = httplib2.Http(timeout=10)
+    http = httplib2.Http(timeout=30)
     http.follow_redirects = True
     return http
 


### PR DESCRIPTION
We were having trouble updating the players and getting timeout errors. It felt like we might be getting rate limited by NFL.com, though not completely sure. Upping the timeout to 30s and also running with `--simultaneous-reqs 1` helped get everything updated.

Thank you for the excellent projects!