### PR TITLE
Parse and format player names with >1 comma

### DIFF
--- a/nflgame/update_players.py
+++ b/nflgame/update_players.py
@@ -176,7 +176,7 @@ def meta_from_soup_row(team, soup_row):
     if ',' not in name:
         last_name, first_name = name, ''
     else:
-        last_name, first_name = map(lambda s: s.strip(), name.split(','))
+        last_name, first_name = map(lambda s: s.strip().replace(',', ''), name.split(',', 1))
 
     return {
         'team': team,


### PR DESCRIPTION
Fixes #316.

This will produce: 
`Leno, Charles, Jr.'` -> `'Leno'`, `'Charles Jr.'`

`name.split(',', 1)` -> only splits on the first occurrence of ',' ensuring not more than 2 items
`s.strip().replace(',', '')` -> removes any remaining commas so that it doesn't affect CSVs


The other PRs would produce the following names:
#277: `'Leno'`, `'Charles, Jr.'`

#266: `'Leno'`, `'Charles'`

Regardless of which fix is the best, one of these should really be merged.